### PR TITLE
Updates and fixes to pass CI

### DIFF
--- a/01_cartpole.ipynb
+++ b/01_cartpole.ipynb
@@ -25,14 +25,7 @@
    "source": [
     "#export\n",
     "\n",
-    "import gym\n",
-    "import time\n",
-    "import logging\n",
-    "\n",
-    "from typing import List\n",
-    "\n",
     "# OpenCog\n",
-    "from opencog.logger import log\n",
     "from opencog.pln import *\n",
     "from opencog.type_constructors import *\n",
     "from opencog.utilities import set_default_atomspace\n",
@@ -42,16 +35,22 @@
     "from rocca.agents import OpencogAgent\n",
     "from rocca.agents.utils import *\n",
     "\n",
-    "from rocca.utils import *\n",
-    "from rocca.agents.core import logger as ac_logger"
+    "from rocca.utils import *"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "eaf7640f",
    "metadata": {},
    "outputs": [],
    "source": [
+    "import gym\n",
+    "import time\n",
+    "import logging\n",
+    "\n",
+    "from opencog.logger import log\n",
+    "from rocca.agents.core import logger as ac_logger\n",
     "from tensorboardX import SummaryWriter"
    ]
   },
@@ -92,7 +91,7 @@
     "        # Call super ctor\n",
     "        super().__init__(env, atomspace, action_space, pgoal, ngoal)\n",
     "\n",
-    "    def plan(self, goal, expiry) -> List:\n",
+    "    def plan(self, goal, expiry) -> list:\n",
     "        \"\"\"Plan the next actions given a goal and its expiry time offset\n",
     "\n",
     "        Return a python list of cognitive schematics.  Whole cognitive\n",
@@ -550,7 +549,13 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.10.0 64-bit",
+   "language": "python",
+   "name": "python3"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ fastcore>=1.3.25
 tensorboard>=2.5.0
 tensorboardX>=2.2
 icecream>=2.1.0
+scipy>=1.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-gym==0.18.3
-orderedmultidict==1.0.1
-fastcore==1.3.25
-minerl==0.4.0
-tensorboard==2.5.0
-tensorboardX==2.2
-icecream==2.1.0
+gym>=0.13.1,<0.20
+minerl>=0.4.0
+orderedmultidict>=1.0.1
+fastcore>=1.3.25
+tensorboard>=2.5.0
+tensorboardX>=2.2
+icecream>=2.1.0

--- a/rocca/agents/cartpole.py
+++ b/rocca/agents/cartpole.py
@@ -4,14 +4,7 @@ __all__ = ["FixedCartPoleAgent", "LearningCartPoleAgent"]
 
 # Cell
 
-import gym
-import time
-import logging
-
-from typing import List
-
 # OpenCog
-from opencog.logger import log
 from opencog.pln import *
 from opencog.type_constructors import *
 from opencog.utilities import set_default_atomspace
@@ -22,7 +15,6 @@ from . import OpencogAgent
 from .utils import *
 
 from ..utils import *
-from .core import logger as ac_logger
 
 # Cell
 
@@ -42,7 +34,7 @@ class FixedCartPoleAgent(OpencogAgent):
         # Call super ctor
         super().__init__(env, atomspace, action_space, pgoal, ngoal)
 
-    def plan(self, goal, expiry) -> List:
+    def plan(self, goal, expiry) -> list:
         """Plan the next actions given a goal and its expiry time offset
 
         Return a python list of cognitive schematics.  Whole cognitive

--- a/rocca/agents/utils.py
+++ b/rocca/agents/utils.py
@@ -17,7 +17,6 @@ import scipy.stats as st
 from opencog.atomspace import (
     Atom,
     AtomSpace,
-    TruthValue,
     get_type,
     is_a,
     types,
@@ -35,6 +34,7 @@ from opencog.type_constructors import (
     IsClosedLink,
     IsTrueLink,
     SatisfactionLink,
+    TruthValue,
 )
 from opencog.utilities import get_free_variables
 

--- a/tests/test_cartpole.py
+++ b/tests/test_cartpole.py
@@ -32,5 +32,5 @@ def test_cartpole():
     cpa.delta = 1.0e-16
 
     # Run control loop
-    while not cpa.step():
+    while not cpa.control_cycle():
         time.sleep(0.1)

--- a/tests/test_cartpole.py
+++ b/tests/test_cartpole.py
@@ -3,17 +3,12 @@ import time
 import gym
 
 from opencog.atomspace import AtomSpace
-from opencog.logger import log
-from opencog.pln import *
-from opencog.spacetime import *
-from opencog.type_constructors import *
-from opencog.ure import ure_logger
 from opencog.utilities import set_default_atomspace
 
-from rocca.agents.cartpole import FixedCartPoleAgent
+from rocca.utils import *
 from rocca.agents.utils import *
 from rocca.envs.wrappers import CartPoleWrapper
-from rocca.utils import *
+from rocca.agents.cartpole import FixedCartPoleAgent
 
 
 # Test if a simple CartPole run works


### PR DESCRIPTION
These changes finally bring us “back in the green” with CI.
- Requirements are more relaxed now so that they don’t have to be updated that often anymore.
- There are a few fixes, including one about importing `TruthValue` — for future reference, `TruthValue` **should not** be imported from `opencog.atomspace`, only from `opencog.type_constructors`. That’s because the former is actually an internal type that expects a pointer, proper construction is done by the latter, which is a helper function.