### PR TITLE
Add a workaround for a setuptools problem

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,7 +31,7 @@
 	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
 	// "shutdownAction": "none",
 	// Uncomment the next line to run commands after the container is created - for example installing git.
-	"postCreateCommand": "python3 -m pip install --user -r requirements-dev.txt && python3 -m pip install --user -e .",
+	"postCreateCommand": "python3 -m pip install --user -r requirements-dev.txt && sudo python3 -m pip install -e .",
 	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
 	// "remoteUser": "vscode"
 }

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ OpenCog tools
 
 Third party tools
 
-- Python 3.9 (or Python 3.8 see below)
+- Python 3.10 (or Python 3.8 see below)
 - python-orderedmultidict https://pypi.org/project/orderedmultidict/
 - fastcore https://fastcore.fast.ai
 - OpenAI Gym https://gym.openai.com/
@@ -71,9 +71,9 @@ Third party tools
 - nbdev https://nbdev.fast.ai
 - black https://pypi.org/project/black/
 
-### Python 3.9 vs 3.8
+### Python 3.10 vs 3.8
 
-Python 3.9 offers a better out-of-the-box type annotation system than
+Python 3.10 offers a better out-of-the-box type annotation system than
 Python 3.8 and is thus the default required version.  However you may
 still use Python 3.8 by checking out the
 [python-3.8-compatible](https://github.com/opencog/rocca/tree/python-3.8-compatible)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
It seems `setuptools` broke something in the latest version, maybe they’re going to fix it but apparently everyone is now supposed to have `pyproject.toml`. Also for some reason user install doesn’t work in that specific case...