### PR TITLE
Add human readable cogscm rendering function + lots of log msgs improvements

### DIFF
--- a/rocca/agents/core.py
+++ b/rocca/agents/core.py
@@ -367,7 +367,7 @@ class OpencogAgent:
         agent_log.fine(
             "pln_fc(atomspace={}, source={}, maximum_iterations={}, full_rule_application={}, rules={})".format(
                 atomspace,
-                source.long_string(),
+                source.id_string(),
                 maximum_iterations,
                 full_rule_application,
                 rules,
@@ -379,8 +379,6 @@ class OpencogAgent:
             scheme_eval(self.atomspace, "(pln-rm-all-rules)")
             for rule in rules:
                 er = scheme_eval(self.atomspace, "(pln-add-rule '" + rule + ")")
-                # agent_log.fine("(pln-add-rule '" + rule + ")")
-                # agent_log.fine("er = " + str(er))
 
         # Log the entire atomspace (fine level), uncomment to enable.
         # agent_log_atomspace(atomspace)
@@ -420,7 +418,7 @@ class OpencogAgent:
 
         agent_log.fine(
             "pln_bc(atomspace={}, target={}, maximum_iterations={}, rules={})".format(
-                atomspace, target.long_string(), maximum_iterations, rules
+                atomspace, target.id_string(), maximum_iterations, rules
             )
         )
 
@@ -429,8 +427,6 @@ class OpencogAgent:
             scheme_eval(self.atomspace, "(pln-rm-all-rules)")
             for rule in rules:
                 er = scheme_eval(self.atomspace, "(pln-add-rule '" + rule + ")")
-                # agent_log.fine("(pln-add-rule '" + rule + ")")
-                # agent_log.fine("er = " + str(er))
 
         # Log the entire atomspace (fine level), uncomment to enable.
         # agent_log_atomspace(atomspace)
@@ -547,7 +543,7 @@ class OpencogAgent:
 
         """
 
-        agent_log.fine("directly_evaluate(atom={})".format(atom))
+        agent_log.fine("directly_evaluate(atom={})".format(atom.id_string()))
 
         # Exit now to avoid division by zero
         if self.total_count == 0:
@@ -836,7 +832,9 @@ class OpencogAgent:
     def to_predictive_implicant(self, pattern: Atom) -> Atom:
         """Turn a temporal pattern into predictive implicant."""
 
-        agent_log.fine("to_predictive_implicant(pattern={})".format(pattern))
+        agent_log.fine(
+            "to_predictive_implicant(pattern={})".format(pattern.id_string())
+        )
 
         timed_clauses = self.get_pattern_timed_clauses(pattern)
         early_clauses = get_early_clauses(timed_clauses)
@@ -943,15 +941,17 @@ class OpencogAgent:
 
         """
 
-        agent_log.fine("to_predictive_implication_scope(pattern={})".format(pattern))
+        agent_log.fine(
+            "to_predictive_implication_scope(pattern={})".format(pattern.id_string())
+        )
 
         # Get the predictive implication implicant and implicand
         # respectively
         pt = self.to_predictive_implicant(pattern)
         pd = self.to_predictive_implicand(pattern)
 
-        agent_log.fine("pt = {}".format(pt))
-        agent_log.fine("pd = {}".format(pd))
+        agent_log.fine("pt = {}".format(pt.id_string()))
+        agent_log.fine("pd = {}".format(pd.id_string()))
 
         # HACK: big hack, pd is turned into positive goal to create a
         # predictive implication of such positive goal with low
@@ -982,7 +982,6 @@ class OpencogAgent:
         if vardecl_vars != pt_vars:
             return None
 
-        agent_log.fine("preimp = {}".format(preimp))
         # Calculate the truth value of the predictive implication
         mi = 2
         rules = ["back-predictive-implication-scope-direct-evaluation"]
@@ -1248,7 +1247,11 @@ class OpencogAgent:
         )
         agent_log.fine("Miner query:\n{}".format(mine_query))
         surprises = scheme_eval_h(atomspace, "(List " + mine_query + ")")
-        agent_log.fine("Surprising patterns:\n{}".format(surprises))
+        agent_log.fine(
+            "Surprising patterns [count={}]:\n{}".format(
+                surprises.arity, surprises.long_string()
+            )
+        )
 
         return surprises.out
 
@@ -1292,7 +1295,8 @@ class OpencogAgent:
         agent_log.fine("plan(goal={}, expiry={})".format(goal, expiry))
         agent_log.fine(
             "self.cognitive_schematics [count={}]:\n{}".format(
-                len(self.cognitive_schematics), self.cognitive_schematics
+                len(self.cognitive_schematics),
+                cogscms_to_str(self.cognitive_schematics),
             )
         )
 
@@ -1355,7 +1359,7 @@ class OpencogAgent:
     def prior_estimate(self, cogscm: Atom) -> float:
         """Calculate the prior probability of cogscm."""
 
-        agent_log.fine("prior_estimate(cogscm={})".format(cogscm.long_string()))
+        agent_log.fine("prior_estimate(cogscm={})".format(cogscm.id_string()))
 
         partial_complexity = self.complexity(cogscm)
         remain_data_size = self.data_set_size - cogscm.tv.count

--- a/rocca/agents/core.py
+++ b/rocca/agents/core.py
@@ -1493,7 +1493,7 @@ class OpencogAgent:
         valid_cogscms = [cogscm for cogscm in cogscms if 0.9 < ctx_tv(cogscm).mean]
         agent_log.fine(
             "Valid cognitive schematics [count={}]:\n{}".format(
-                len(valid_cogscms), cogscms_to_str(valid_cogscms)
+                len(valid_cogscms), cogscms_to_str(valid_cogscms, only_id=True)
             )
         )
 

--- a/rocca/agents/core.py
+++ b/rocca/agents/core.py
@@ -477,7 +477,7 @@ class OpencogAgent:
             pos_prdi = self.surprises_to_predictive_implications(pos_srps)
             agent_log.fine(
                 "Mined positive goal cognitive schematics [count={}]:\n{}".format(
-                    len(pos_prdi), pos_prdi
+                    len(pos_prdi), cogscms_to_str(pos_prdi)
                 )
             )
             cogscms.update(set(pos_prdi))
@@ -490,7 +490,7 @@ class OpencogAgent:
             neg_prdi = self.surprises_to_predictive_implications(neg_srps)
             agent_log.fine(
                 "Mined negative goal cognitive schematics [count={}]:\n{}".format(
-                    len(neg_prdi), neg_prdi
+                    len(neg_prdi), cogscms_to_str(neg_prdi)
                 )
             )
             cogscms.update(set(neg_prdi))
@@ -504,7 +504,7 @@ class OpencogAgent:
                 gen_prdi = self.surprises_to_predictive_implications(gen_srps)
                 agent_log.fine(
                     "Mined general succedent cognitive schematics [count={}]:\n{}".format(
-                        len(gen_prdi), gen_prdi
+                        len(gen_prdi), cogscms_to_str(gen_prdi)
                     )
                 )
                 cogscms.update(set(gen_prdi))
@@ -524,7 +524,7 @@ class OpencogAgent:
                     )
                     agent_log.fine(
                         "Mined positive goal poly-action cognitive schematics[count={}]\n:{}".format(
-                            len(pos_poly_srps), pos_poly_srps
+                            len(pos_poly_srps), cogscms_to_str(pos_poly_srps)
                         )
                     )
                     pos_poly_prdi = self.surprises_to_predictive_implications(
@@ -533,7 +533,9 @@ class OpencogAgent:
                     cogscms.update(set(pos_poly_prdi))
 
         agent_log.fine(
-            "Mined cognitive schematics [count={}]:\n{}".format(len(cogscms), cogscms)
+            "Mined cognitive schematics [count={}]:\n{}".format(
+                len(cogscms), cogscms_to_str(cogscms)
+            )
         )
         return cogscms
 
@@ -695,7 +697,7 @@ class OpencogAgent:
         # Log all inferred cognitive schematics
         agent_log.fine(
             "Inferred cognitive schematics [count={}]:\n{}".format(
-                len(cogscms), cogscms
+                len(cogscms), cogscms_to_str(cogscms)
             )
         )
 
@@ -1007,7 +1009,7 @@ class OpencogAgent:
         """
 
         # For logging
-        cogscm_str = cogscm.long_string() if cogscm else str(cogscm)
+        cogscm_str = cogscm_to_str(cogscm) if cogscm else str(cogscm)
         msg = "{} is undesirable because ".format(cogscm_str)
 
         # Check that cogscm is defined
@@ -1490,7 +1492,9 @@ class OpencogAgent:
         )
         valid_cogscms = [cogscm for cogscm in cogscms if 0.9 < ctx_tv(cogscm).mean]
         agent_log.fine(
-            "valid_cogscms [count={}]:\n{}".format(len(valid_cogscms), valid_cogscms)
+            "Valid cognitive schematics [count={}]:\n{}".format(
+                len(valid_cogscms), cogscms_to_str(valid_cogscms)
+            )
         )
 
         # Size of the complete data set, including all observations
@@ -1581,7 +1585,9 @@ class OpencogAgent:
         # Plan, i.e. come up with cognitive schematics as plans.  Here the
         # goal expiry is 2, i.e. must be fulfilled set for the next two iterations.
         cogscms = self.plan(goal, self.expiry)
-        agent_log.debug("cogscms [count={}]:\n{}".format(len(cogscms), cogscms))
+        agent_log.debug(
+            "cogscms [count={}]:\n{}".format(len(cogscms), cogscms_to_str(cogscms))
+        )
 
         # Deduce the action distribution
         mxmdl = self.deduce(cogscms)

--- a/rocca/agents/utils.py
+++ b/rocca/agents/utils.py
@@ -1203,32 +1203,30 @@ def to_human_readable_str(atom: Atom, parenthesis: bool = False) -> str:
     return "(" + final_str + ")" if parenthesis else final_str
 
 
-def cogscm_to_str(cogscm: Atom) -> str:
+def cogscm_to_str(cogscm: Atom, only_id: bool = False) -> str:
     """Convert a cognitive schematics to string.
 
-    The cognitive schematic is turned into a string in Scheme format,
-    prepended with a comment of its human readable form (see
-    to_human_readable_str).
+    Represent the human readable form of cogscm, then on the next line
+    its Scheme representation.  If only_id is True, then only its ID,
+    instead of the whole Scheme representation, is rendered.
 
     """
 
     msg = ";; " + to_human_readable_str(cogscm) + "\n"
-    msg += cogscm.long_string()
+    msg += cogscm.id_string() if only_id else cogscm.long_string()
     return msg
 
 
-def cogscms_to_str(cogscms: set[Atom] | list[Atom]) -> str:
+def cogscms_to_str(cogscms: set[Atom] | list[Atom], only_id: bool = False) -> str:
     """Convert a collection of cognitive schematics to string.
 
-    Each cognitive schematic is turned into a string in Scheme format,
-    prepended with a comment of its human readable form (see
-    to_human_readable_str).
+    Apply cogscm_to_str to a collection of cogscms.
 
     """
 
     msgs = []
     for cogscm in cogscms:
-        msgs.append(cogscm_to_str(cogscm))
+        msgs.append(cogscm_to_str(cogscm, only_id))
     return "\n".join(msgs)
 
 

--- a/rocca/agents/utils.py
+++ b/rocca/agents/utils.py
@@ -20,6 +20,7 @@ from opencog.atomspace import (
     Atom,
     AtomSpace,
     get_type,
+    get_type_name,
     is_a,
     types,
     createTruthValue,
@@ -1202,7 +1203,37 @@ def to_human_readable_str(atom: Atom, parenthesis: bool = False) -> str:
     return "(" + final_str + ")" if parenthesis else final_str
 
 
+def cogscm_to_str(cogscm: Atom) -> str:
+    """Convert a cognitive schematics to string.
+
+    The cognitive schematic is turned into a string in Scheme format,
+    prepended with a comment of its human readable form (see
+    to_human_readable_str).
+
+    """
+
+    msg = ";; " + to_human_readable_str(cogscm) + "\n"
+    msg += cogscm.long_string()
+    return msg
+
+
+def cogscms_to_str(cogscms: set[Atom] | list[Atom]) -> str:
+    """Convert a collection of cognitive schematics to string.
+
+    Each cognitive schematic is turned into a string in Scheme format,
+    prepended with a comment of its human readable form (see
+    to_human_readable_str).
+
+    """
+
+    msgs = []
+    for cogscm in cogscms:
+        msgs.append(cogscm_to_str(cogscm))
+    return "\n".join(msgs)
+
+
 class MinerLogger:
+
     """Quick and dirty miner logger Python bindings"""
 
     def __init__(self, atomspace: AtomSpace):

--- a/rocca/agents/utils.py
+++ b/rocca/agents/utils.py
@@ -1009,8 +1009,8 @@ def syntax_precede(a1: Atom, a2: Atom) -> bool:
 
     Precedence order is as follows
 
-    1. Concept/Predicate/Schema
-    2. Evaluation/Execution
+    1. Variable/Number/Concept/Predicate/Schema
+    2. Evaluation/Execution/GreaterThan
     3. Not
     4. And/Or
     5. SequentialAnd
@@ -1026,14 +1026,15 @@ def syntax_precede(a1: Atom, a2: Atom) -> bool:
 
     """
 
-    print("syntax_precede(a1={}, a2={})".format(a1, a2))
-
     precedence = {
+        types.VariableNode: 1,
+        types.NumberNode: 1,
         types.ConceptNode: 1,
         types.PredicateNode: 1,
         types.SchemaNode: 1,
         types.EvaluationLink: 2,
         types.ExecutionLink: 2,
+        types.GreaterThanLink: 2,
         types.NotLink: 3,
         types.AndLink: 4,
         types.OrLink: 4,
@@ -1044,15 +1045,16 @@ def syntax_precede(a1: Atom, a2: Atom) -> bool:
     return precedence[a1.type] < precedence[a2.type]
 
 
-# Add type annotation on ty
+# TODO: add type annotation on ty
 def type_to_human_readable_str(ty) -> str:
-    """Convert atom type to human readable character
+    """Convert atom type to human readable character.
 
     The conversion goes as follows
 
     And                          -> ∧
     Or                           -> ∨
     Not                          -> ¬
+    GreaterThan                  -> >
     SequentialAnd                -> ≺
     PredictiveImplication[Scope] -> ↝
     Execution                    -> do
@@ -1063,8 +1065,10 @@ def type_to_human_readable_str(ty) -> str:
         types.NotLink: "∨",
         types.AndLink: "∧",
         types.OrLink: "¬",
+        types.GreaterThanLink: ">",
         types.ExecutionLink: "do",
         get_type("BackSequentialAndLink"): "≺",
+        get_type("BackPredictiveImplicationScope"): "↝",
         get_type("BackPredictiveImplicationScopeLink"): "↝",
     }
 
@@ -1136,7 +1140,9 @@ def to_human_readable_str(atom: Atom, parenthesis: bool = False) -> str:
     ##############
 
     if atom.is_node():
-        return "(" + atom.name + ")" if parenthesis else atom.name
+        obj_str = atom.name
+        obj_str = obj_str.replace(" ", "")  # Remove whitespace
+        return "(" + obj_str + ")" if parenthesis else obj_str
 
     ###################
     # Recursive cases #
@@ -1163,6 +1169,7 @@ def to_human_readable_str(atom: Atom, parenthesis: bool = False) -> str:
         # and the arguments are the renaming outgoings (possibly
         # wrapped in a ListLink.
         op_str = atom.out[0].name
+        op_str = op_str.replace(" ", "")  # Remove whitespace
         arg = atom.out[1]
         out = arg.out if is_list(arg) else [arg]
         is_infix = False

--- a/tests/agents/test_utils.py
+++ b/tests/agents/test_utils.py
@@ -8,12 +8,22 @@ from opencog.type_constructors import (
     PredicateNode,
     ConceptNode,
     TruthValue,
+    VariableSet,
+    AndLink,
+    ExecutionLink,
+    SchemaNode,
+)
+from opencog.pln import (
+    SLink,
+    ZLink,
+    BackPredictiveImplicationScopeLink,
+    BackSequentialAndLink,
 )
 from opencog.atomspace import AtomSpace, createTruthValue
 from opencog.utilities import set_default_atomspace
 
 # ROCCA
-from rocca.agents.utils import shannon_entropy, differential_entropy, get_uniq_atoms
+from rocca.agents.utils import shannon_entropy, differential_entropy, get_uniq_atoms, to_human_readable_str
 
 # Set main atomspace
 atomspace = AtomSpace()
@@ -158,3 +168,27 @@ def test_get_uniq_atoms():
 
     # Test all uniq atoms of PAA
     assert get_uniq_atoms(PAA) == {P, A, AA, PAA}
+
+
+def test_to_human_readable_str():
+    cogscm = BackPredictiveImplicationScopeLink(
+        VariableSet(),
+        SLink(ZLink()),
+        AndLink(
+            EvaluationLink(
+                PredicateNode("outside"),
+                ListLink(
+                    ConceptNode("self"),
+                    ConceptNode("house"))),
+            ExecutionLink(
+                SchemaNode("go_to_key"))),
+        EvaluationLink(
+            PredicateNode("hold"),
+            ListLink(
+                ConceptNode("self"),
+                ConceptNode("key"))))
+
+    cogscm_hrs = to_human_readable_str(cogscm)
+    expected = "outside(self, house) ∧ do(go_to_key) ↝ hold(self, key)"
+
+    assert cogscm_hrs == expected


### PR DESCRIPTION
The main addition of this PR is a function to turn cognitive schematics such as

```
(BackPredictiveImplicationScopeLink (stv 1 0.00891089)
  (VariableSet
  ) ; [80075fffffff523a][3]
  (SLink
    (ZLink
    ) ; [800fbffffffe8ce4][3]
  ) ; [da5f815ba9d4009f][3]
  (BackSequentialAndLink
    (SLink
      (ZLink
      ) ; [800fbffffffe8ce4][3]
    ) ; [da5f815ba9d4009f][3]
    (AndLink (stv 0.1 0.2)
      (ExecutionLink
        (SchemaNode "Go Left") ; [7ca250f2efc2e872][3]
      ) ; [c7fb76d9605d5db5][3]
      (EvaluationLink (stv 0.605 0.2)
        (PredicateNode "Agent Position") ; [3fdca752fd5e5335][3]
        (ConceptNode "Right Square") ; [6dd382acb6aa376e][3]
      ) ; [c9fcc2094e0150df][3]
      (EvaluationLink (stv 0.61 0.2)
        (PredicateNode "Pellet Position") ; [56e6ab0f525cb504][3]
        (ConceptNode "Left Square") ; [586f8a0db3b1388a][3]
      ) ; [eff67c574737d4d6][3]
    ) ; [90be7e9894b149fd][3]
    (ExecutionLink
      (SchemaNode "Eat") ; [3fe4e22345c3679f][3]
    ) ; [9efce1dc8918c209][3]
  ) ; [f64d0fb50dd6139c][3]
  (EvaluationLink (stv 0.075 0.2)
    (PredicateNode "Reward") ; [155bb4d713db0d51][3]
    (NumberNode "1") ; [2cf0956d543cff8e][3]
  ) ; [d3cee8bdda06ffcb][3]
) ; [e5b935e5eae8c50c][3]
```

into

```
AgentPosition(RightSquare) ∧ PelletPosition(LeftSquare) ∧ do(GoLeft) ≺ do(Eat) ↝ Reward(1)
```

making for much more readable log messages.